### PR TITLE
Adding {{with (route-params params)}} helper to yield params to block

### DIFF
--- a/addon/helpers/route-params.js
+++ b/addon/helpers/route-params.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+import _RouteParams from '../utils/route-params';
+
+let RouteParams = _RouteParams;
+export function setRouteParamsClass(klass) {
+  RouteParams = klass;
+}
+
+export default Ember.Helper.extend({
+  router: Ember.inject.service(),
+
+  compute(params) {
+    return new RouteParams(this.get('router'), params);
+  }
+});

--- a/addon/utils/route-params.js
+++ b/addon/utils/route-params.js
@@ -1,0 +1,50 @@
+import Ember from 'ember';
+
+export default class RouteParams {
+  constructor(router, params) {
+    this._router = router;
+    this._params = params;
+    this._transitionTo = undefined;
+    this._replaceWith = undefined;
+
+    /*
+      We need to opt out of Ember eagerly pulling on the getters defined in this class. This is due to
+      watchKeys (https://github.com/emberjs/ember.js/blob/d8880eed573a56c8a9172ef9d2bebcfe8fd25582/packages/ember-metal/lib/watch_key.js#L24)
+      getting a property to check for reference counting. Without this, our intentionally lazy getter is evaluated twice
+      in a single render.
+    */
+    let m = Ember.meta(this);
+    m.writeWatching('isActive', 1);
+    m.writeWatching('url', 1);
+    m.writeWatching('transitionTo', 1);
+    m.writeWatching('replaceWith', 1);
+  }
+
+  get isActive() {
+    return this._router.isActive(...this._params);
+  }
+
+  get url() {
+    return this._router.urlFor(...this._params);
+  }
+
+  get transitionTo() {
+    if (this._transitionTo === undefined) {
+      this._transitionTo = () => {
+        return this._router.transitionTo(...this._params);
+      };
+    }
+
+    return this._transitionTo;
+  }
+
+  get replaceWith() {
+    if (this._replaceWith === undefined) {
+      this._replaceWith = () => {
+        return this._router.replaceWith(...this._params);
+      };
+    }
+
+    return this._replaceWith;
+  }
+}

--- a/app/helpers/route-params.js
+++ b/app/helpers/route-params.js
@@ -1,0 +1,1 @@
+export { default, routeParams } from 'ember-router-helpers/helpers/route-params';

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-native-dom-helpers": "^0.5.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.14.0-beta.1",
     "loader.js": "^4.2.3"

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,7 +1,6 @@
 /* eslint-env node */
 module.exports = {
   browsers: [
-    'ie 9',
     'last 1 Chrome versions',
     'last 1 Firefox versions',
     'last 1 Safari versions'

--- a/tests/integration/helpers/route-params-test.js
+++ b/tests/integration/helpers/route-params-test.js
@@ -1,0 +1,142 @@
+
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { setRouteParamsClass } from 'ember-router-helpers/helpers/route-params';
+import RouteParams from 'ember-router-helpers/utils/route-params';
+import { click } from 'ember-native-dom-helpers';
+
+moduleForComponent('route-params', 'helper:route-params', {
+  integration: true,
+
+  beforeEach() {
+    this.owner = Ember.getOwner(this);
+    this.owner.lookup('router:main').setupRouter();
+  },
+
+  afterEach() {
+    setRouteParamsClass(RouteParams);
+  }
+});
+
+test('route-params yields correct URL value', function(assert) {
+  this.render(hbs`
+    {{#with (route-params 'parent.child') as |routeParams|}}
+      {{routeParams.url}}
+    {{/with}}`
+  );
+
+  assert.equal(this.$().text().trim(), '/child');
+});
+
+test('route-params only calls urlFor once per render', function(assert) {
+  assert.expect(1);
+
+  let router = this.owner.lookup('service:router');
+  router.urlFor = () => {
+    assert.ok(true, 'urlFor called');
+    return '/foo';
+  }
+
+  this.render(hbs`
+    {{#with (route-params 'parent.child') as |routeParams|}}
+      {{routeParams.url}}
+    {{/with}}`);
+});
+
+test('route-params only calls transitionTo once per render', function(assert) {
+  assert.expect(1);
+
+  class MockedRouteParams extends RouteParams {
+    get transitionTo() {
+      assert.ok(true, 'transitionTo called');
+      return super.transitionTo;
+    }
+  }
+
+  setRouteParamsClass(MockedRouteParams);
+
+  this.render(hbs`
+    {{#with (route-params 'parent.child') as |routeParams|}}
+      {{routeParams.transitionTo}}
+    {{/with}}`);
+});
+
+test('route-params actions invoke transitionTo', async function(assert) {
+  assert.expect(1);
+
+  class MockedRouteParams extends RouteParams {
+    get transitionTo() {
+      return () => {
+        assert.ok(true, 'transtionTo invoked');
+      };
+    }
+  }
+
+  setRouteParamsClass(MockedRouteParams);
+
+  this.render(hbs`
+    {{#with (route-params 'parent.child') as |routeParams|}}
+      <button {{action routeParams.transitionTo}}></button>
+    {{/with}}`);
+
+  await click('button');
+});
+
+test('route-params only calls replaceWith once per render', function(assert) {
+  assert.expect(1);
+
+  class MockedRouteParams extends RouteParams {
+    get replaceWith() {
+      assert.ok(true, 'replaceWith called');
+      return super.replaceWith;
+    }
+  }
+
+  setRouteParamsClass(MockedRouteParams);
+
+  this.render(hbs`
+    {{#with (route-params 'parent.child') as |routeParams|}}
+      {{routeParams.replaceWith}}
+    {{/with}}`);
+});
+
+test('route-params actions invoke replaceWith', async function(assert) {
+  assert.expect(1);
+
+  class MockedRouteParams extends RouteParams {
+    get replaceWith() {
+      return () => {
+        assert.ok(true, 'replaceWith invoked');
+      };
+    }
+  }
+
+  setRouteParamsClass(MockedRouteParams);
+
+  this.render(hbs`
+    {{#with (route-params 'parent.child') as |routeParams|}}
+      <button {{action routeParams.replaceWith}}></button>
+    {{/with}}`
+  );
+
+  await click('button');
+});
+
+test('route-params yields correct isActive value', function(assert) {
+  assert.expect(2);
+
+  let router = this.owner.lookup('service:router');
+  router.isActive = () => {
+    assert.ok(true, 'isActive called');
+    return true;
+  }
+
+  this.render(hbs`
+    {{#with (route-params 'parent.child') as |routeParams|}}
+      <a href="{{routeParams.url}}" class="{{if routeParams.isActive 'active' 'inactive'}}">Blah</a>
+    {{/with}}`
+  );
+
+  assert.ok(this.$('a').hasClass('active'));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2007,6 +2007,13 @@ ember-load-initializers@^1.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-native-dom-helpers@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.0.tgz#a3a12215cfdfa518472e203fdc15b485cea23670"
+  dependencies:
+    broccoli-funnel "^1.1.0"
+    ember-cli-babel "^6.1.0"
+
 ember-qunit@^2.1.3:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-2.1.4.tgz#5732794e668f753d8fe1a353692ffeda73742d29"


### PR DESCRIPTION
**Changes**

* Added `route-params` class to encapsulate properties and lazy-loaded methods. 
* Added `route-params` helper.