### PR TITLE
Recompute active class if currentURL changes

### DIFF
--- a/addon/helpers/is-active.js
+++ b/addon/helpers/is-active.js
@@ -4,6 +4,10 @@ import handleQueryParams from '../utils/handle-query-params';
 export default Ember.Helper.extend({
   router: Ember.inject.service(),
 
+  currentURLObserver: Ember.observer('router.currentURL', function() {
+    this.recompute();
+  }),
+
   compute(_params) {
     let params = handleQueryParams(_params);
     return this.get('router').isActive(...params);

--- a/addon/helpers/route-params.js
+++ b/addon/helpers/route-params.js
@@ -9,6 +9,10 @@ export function setRouteParamsClass(klass) {
 export default Ember.Helper.extend({
   router: Ember.inject.service(),
 
+  currentURLObserver: Ember.observer('router.currentURL', function() {
+    this.recompute();
+  }),
+
   compute(params) {
     return new RouteParams(this.get('router'), params);
   }

--- a/tests/integration/helpers/is-active-test.js
+++ b/tests/integration/helpers/is-active-test.js
@@ -1,0 +1,46 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
+
+const RouterServiceMock = Ember.Service.extend({
+  currentRouteName: Ember.computed('currentURL', function() {
+    return this.get('currentURL').substring(1);
+  }),
+
+  isActive(routeName) {
+    return this.get('currentRouteName') === routeName;
+  }
+});
+
+moduleForComponent('is-active', 'helper:is-active', {
+  integration: true,
+
+  beforeEach() {
+    this.owner = Ember.getOwner(this);
+    this.owner.register('service:router', RouterServiceMock);
+  }
+});
+
+test('it renders and rerenders when currentURL changes', async function(assert) {
+  const router = this.owner.lookup('service:router');
+
+  router.set('currentURL', '/foo');
+  this.set('targetRoute', 'bar');
+  this.render(hbs`{{is-active targetRoute}}`);
+
+  assert.equal(this.$().text(), 'false', 'is-active is not true when curren route is different from target route');
+
+  router.set('currentURL', '/bar');
+
+  await wait();
+
+  assert.equal(this.$().text(), 'true', 'is-active is true now when URL has changed');
+
+  router.set('currentURL', '/foo');
+
+  await wait();
+
+  assert.equal(this.$().text(), 'false', 'is-active is false when URL has changed');
+});
+

--- a/tests/integration/helpers/route-params-test.js
+++ b/tests/integration/helpers/route-params-test.js
@@ -1,10 +1,10 @@
-
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { setRouteParamsClass } from 'ember-router-helpers/helpers/route-params';
 import RouteParams from 'ember-router-helpers/utils/route-params';
 import { click } from 'ember-native-dom-helpers';
+import wait from 'ember-test-helpers/wait';
 
 moduleForComponent('route-params', 'helper:route-params', {
   integration: true,
@@ -175,13 +175,15 @@ test('route-params actions invoke replaceWith', async function(assert) {
   await click('button');
 });
 
-test('route-params yields correct isActive value', function(assert) {
-  assert.expect(2);
+test('route-params yields correct isActive value', async function(assert) {
+  assert.expect(6);
 
+  let currentURL = '/current-url';
   let router = this.owner.lookup('service:router');
+  router.currentURL = currentURL;
   router.isActive = () => {
     assert.ok(true, 'isActive called');
-    return true;
+    return router.get('currentURL') === currentURL;
   }
 
   this.render(hbs`
@@ -191,4 +193,15 @@ test('route-params yields correct isActive value', function(assert) {
   );
 
   assert.ok(this.$('a').hasClass('active'));
+
+  router.set('currentURL', '/different-url');
+
+  await wait();
+
+  assert.notOk(this.$('a').hasClass('active'), 'different url => link is not active anymore');
+  router.set('currentURL', currentURL);
+
+  await wait();
+
+  assert.ok(this.$('a').hasClass('active'), 'same url => link is active again');  
 });


### PR DESCRIPTION
I've tried running the acceptance test with it and there seem to be some legit issues with query params + route-params helper. I think this issue is not present when using the helpers separately (no route-params), but I'll update the acceptance test so that it tests the same scenarios with the route-params and regular usage.