### PR TITLE
Fix docs for is-active helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ember install ember-router-helpers
 * `is-active`
 
 ```hbs
-{{is-active '/parent/child'}}
+{{is-active 'parent.child'}}
 ```
 
 * `url-for`


### PR DESCRIPTION
The current example for the `{{is-active}}` helper documentation is passing a path rather than a route name. This fixes that.